### PR TITLE
feat(md): exported terms linked to the type index

### DIFF
--- a/src/lib/lib/markdown.ts
+++ b/src/lib/lib/markdown.ts
@@ -53,6 +53,17 @@ export function codeSpan(n: Node): Renderable {
 }
 
 /**
+ * A markdown link.
+ */
+export function link(text: Node, url: string): Renderable {
+  return {
+    render(state) {
+      return `[${render(state, text)}](${url})`
+    },
+  }
+}
+
+/**
  * A heading.
  */
 export function heading(n: number, content: Node): Renderable {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -4,6 +4,7 @@ const sources = [
 
     export { fooFromB }
 
+
     /**
      * Toto
      */

--- a/test/markdown/markdown.spec.ts
+++ b/test/markdown/markdown.spec.ts
@@ -49,3 +49,30 @@ describe('options', () => {
     })
   })
 })
+
+it('term exports whose type is in the typeindex are linked to that typeindex entry', () => {
+  expect(
+    ctx.markdown(
+      { flatTermsSection: true },
+      `
+        export let a: A = {}
+        interface A {}
+      `
+    )
+  ).toMatchInlineSnapshot(`
+"### \`a\`
+
+Of type [\`A\`](#i-a)
+
+### Exported Types
+
+### Type Index
+
+#### \`I\` \`A\`
+
+\`\`\`ts
+interface A {}
+\`\`\`
+"
+`)
+})


### PR DESCRIPTION
closes #14