### PR TITLE
feat: track module paths

### DIFF
--- a/src/cli/commands/project.ts
+++ b/src/cli/commands/project.ts
@@ -32,6 +32,7 @@ export class Project extends Command {
 
     const docs = TyDoc.fromProject({
       entrypoints: argv,
+      readSettingsFromJSON: true,
     })
 
     if (flags.json) {

--- a/test/extract/__snapshots__/alias.spec.ts.snap
+++ b/test/extract/__snapshots__/alias.spec.ts.snap
@@ -50,10 +50,11 @@ exports[`exported type alias of array via typeof is added to type index 1`] = `
 Object {
   "modules": Array [
     Object {
+      "isMain": true,
       "jsdoc": null,
       "kind": "module",
       "location": Object {
-        "absoluteFilePath": "/a.ts",
+        "absoluteFilePath": "/src/a.ts",
       },
       "mainExport": null,
       "name": "a",
@@ -69,6 +70,7 @@ Object {
           },
         },
       ],
+      "path": "/",
     },
   ],
   "typeIndex": Object {

--- a/test/extract/__snapshots__/type-alias-object.spec.ts.snap
+++ b/test/extract/__snapshots__/type-alias-object.spec.ts.snap
@@ -239,10 +239,11 @@ exports[`can be self recursive 1`] = `
 Object {
   "modules": Array [
     Object {
+      "isMain": true,
       "jsdoc": null,
       "kind": "module",
       "location": Object {
-        "absoluteFilePath": "/a.ts",
+        "absoluteFilePath": "/src/a.ts",
       },
       "mainExport": null,
       "name": "a",
@@ -258,6 +259,7 @@ Object {
           },
         },
       ],
+      "path": "/",
     },
   ],
   "typeIndex": Object {

--- a/test/extract/array.spec.ts
+++ b/test/extract/array.spec.ts
@@ -6,10 +6,11 @@ it('passes smoke test', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": null,
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
@@ -25,6 +26,7 @@ it('passes smoke test', () => {
               },
             },
           ],
+          "path": "/",
         },
       ],
       "typeIndex": Object {

--- a/test/extract/extract.spec.ts
+++ b/test/extract/extract.spec.ts
@@ -196,10 +196,11 @@ it.only('passes smoke test', () => {
 Object {
   "modules": Array [
     Object {
+      "isMain": true,
       "jsdoc": null,
       "kind": "module",
       "location": Object {
-        "absoluteFilePath": "/a.ts",
+        "absoluteFilePath": "/src/a.ts",
       },
       "mainExport": null,
       "name": "a",
@@ -399,6 +400,7 @@ Object {
           },
         },
       ],
+      "path": "/",
     },
   ],
   "typeIndex": Object {

--- a/test/extract/intersection.spec.ts
+++ b/test/extract/intersection.spec.ts
@@ -97,10 +97,11 @@ it.only('gets each member of the intersection when inside a union', () => {
 Object {
   "modules": Array [
     Object {
+      "isMain": true,
       "jsdoc": null,
       "kind": "module",
       "location": Object {
-        "absoluteFilePath": "/a.ts",
+        "absoluteFilePath": "/src/a.ts",
       },
       "mainExport": null,
       "name": "a",
@@ -116,6 +117,7 @@ Object {
           },
         },
       ],
+      "path": "/",
     },
   ],
   "typeIndex": Object {

--- a/test/extract/jsdoc-module.spec.ts
+++ b/test/extract/jsdoc-module.spec.ts
@@ -11,19 +11,23 @@ it('extracts first comment in an empty file', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": Object {
             "raw": "/**
      * ...
      */",
+            "summary": "...
+    ",
             "tags": Array [],
           },
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
           "namedExports": Array [],
+          "path": "/",
         },
       ],
       "typeIndex": Object {},
@@ -48,19 +52,23 @@ it('extracts first comment above an import node', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": Object {
             "raw": "/**
      * ...
      */",
+            "summary": "...
+    ",
             "tags": Array [],
           },
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
           "namedExports": Array [],
+          "path": "/",
         },
       ],
       "typeIndex": Object {},
@@ -85,15 +93,18 @@ it('extracts first comment above an export node', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": Object {
             "raw": "/**
      * ...
      */",
+            "summary": "...
+    ",
             "tags": Array [],
           },
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
@@ -109,6 +120,7 @@ it('extracts first comment above an export node', () => {
               },
             },
           ],
+          "path": "/",
         },
       ],
       "typeIndex": Object {},
@@ -134,19 +146,23 @@ it('extracts leadig comment above any node if node has own comment', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": Object {
             "raw": "/**
      * ...
      */",
+            "summary": "...
+    ",
             "tags": Array [],
           },
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
           "namedExports": Array [],
+          "path": "/",
         },
       ],
       "typeIndex": Object {},
@@ -165,22 +181,24 @@ it('does not extract leadig comment if appears to be for a piece of code', () =>
       `
     )
   ).toMatchInlineSnapshot(`
-Object {
-  "modules": Array [
     Object {
-      "jsdoc": null,
-      "kind": "module",
-      "location": Object {
-        "absoluteFilePath": "/a.ts",
-      },
-      "mainExport": null,
-      "name": "a",
-      "namedExports": Array [],
-    },
-  ],
-  "typeIndex": Object {},
-}
-`)
+      "modules": Array [
+        Object {
+          "isMain": true,
+          "jsdoc": null,
+          "kind": "module",
+          "location": Object {
+            "absoluteFilePath": "/src/a.ts",
+          },
+          "mainExport": null,
+          "name": "a",
+          "namedExports": Array [],
+          "path": "/",
+        },
+      ],
+      "typeIndex": Object {},
+    }
+  `)
 })
 
 it('does not extract leadig comment if there is none', () => {
@@ -191,22 +209,24 @@ it('does not extract leadig comment if there is none', () => {
       `
     )
   ).toMatchInlineSnapshot(`
-Object {
-  "modules": Array [
     Object {
-      "jsdoc": null,
-      "kind": "module",
-      "location": Object {
-        "absoluteFilePath": "/a.ts",
-      },
-      "mainExport": null,
-      "name": "a",
-      "namedExports": Array [],
-    },
-  ],
-  "typeIndex": Object {},
-}
-`)
+      "modules": Array [
+        Object {
+          "isMain": true,
+          "jsdoc": null,
+          "kind": "module",
+          "location": Object {
+            "absoluteFilePath": "/src/a.ts",
+          },
+          "mainExport": null,
+          "name": "a",
+          "namedExports": Array [],
+          "path": "/",
+        },
+      ],
+      "typeIndex": Object {},
+    }
+  `)
 })
 
 it('does not extract leadig comment from totally empty file', () => {
@@ -214,14 +234,16 @@ it('does not extract leadig comment from totally empty file', () => {
 Object {
   "modules": Array [
     Object {
+      "isMain": true,
       "jsdoc": null,
       "kind": "module",
       "location": Object {
-        "absoluteFilePath": "/a.ts",
+        "absoluteFilePath": "/src/a.ts",
       },
       "mainExport": null,
       "name": "a",
       "namedExports": Array [],
+      "path": "/",
     },
   ],
   "typeIndex": Object {},

--- a/test/extract/jsdoc.spec.ts
+++ b/test/extract/jsdoc.spec.ts
@@ -16,10 +16,11 @@ it('interfaces can have jsdoc', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": null,
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
@@ -35,6 +36,7 @@ it('interfaces can have jsdoc', () => {
               },
             },
           ],
+          "path": "/",
         },
       ],
       "typeIndex": Object {
@@ -47,6 +49,7 @@ it('interfaces can have jsdoc', () => {
 
     bar
     ",
+            "summary": "",
             "tags": Array [
               Object {
                 "name": "a",

--- a/test/extract/typeof.spec.ts
+++ b/test/extract/typeof.spec.ts
@@ -9,10 +9,11 @@ it('inlines the type extracted from the term', () => {
     Object {
       "modules": Array [
         Object {
+          "isMain": true,
           "jsdoc": null,
           "kind": "module",
           "location": Object {
-            "absoluteFilePath": "/a.ts",
+            "absoluteFilePath": "/src/a.ts",
           },
           "mainExport": null,
           "name": "a",
@@ -38,6 +39,7 @@ it('inlines the type extracted from the term', () => {
               },
             },
           ],
+          "path": "/",
         },
       ],
       "typeIndex": Object {

--- a/test/integration.spec.ts
+++ b/test/integration.spec.ts
@@ -129,10 +129,11 @@ it('tydoc can extract data', () => {
 Object {
   "modules": Array [
     Object {
+      "isMain": true,
       "jsdoc": null,
       "kind": "module",
       "location": Object {
-        "absoluteFilePath": "/a.ts",
+        "absoluteFilePath": "/src/a.ts",
       },
       "mainExport": null,
       "name": "a",
@@ -320,6 +321,7 @@ export function foo(a: string, b: number) {}",
           },
         },
       ],
+      "path": "/",
     },
   ],
   "typeIndex": Object {

--- a/test/markdown/markdown.spec.ts
+++ b/test/markdown/markdown.spec.ts
@@ -76,3 +76,33 @@ interface A {}
 "
 `)
 })
+
+it('module doc if present above terms', () => {
+  expect(
+    ctx.markdown(
+      { flatTermsSection: true },
+      `
+        /**
+         * About this module...
+         */
+
+        /**
+         *  About a...
+         */
+        export let a = 1
+      `
+    )
+  ).toMatchInlineSnapshot(`
+"About this module...
+
+### \`a\`
+
+\`\`\`ts
+\`\`\`
+
+### Exported Types
+
+### Type Index
+"
+`)
+})

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -5,7 +5,8 @@ import * as jsde from '../src'
 function createContextt() {
   const project = new tsm.Project({
     compilerOptions: {
-      rootDir: '/',
+      rootDir: './src',
+      outDir: './dist',
     },
     addFilesFromTsConfig: false,
     useInMemoryFileSystem: true,
@@ -28,7 +29,7 @@ function createContextt() {
       sourcesFormatted
         .map(source => [letters.shift()!, source])
         .forEach(([moduleName, source]) =>
-          project.createSourceFile(`${moduleName}.ts`, source, {
+          project.createSourceFile(`./src/${moduleName}.ts`, source, {
             overwrite: true,
           })
         )
@@ -36,6 +37,9 @@ function createContextt() {
       return jsde.fromProject({
         entrypoints: ['a'],
         project: project,
+        prjDir: '/',
+        readSettingsFromJSON: false,
+        packageMainEntrypoint: project.compilerOptions.get().outDir + '/a.js',
       })
     },
   }


### PR DESCRIPTION
closes #18
closes #17 

- Using TSDoc to parse the JSDoc string. Works well, API is simple. Checkout the Quokka playground in this repo for a test drive.
- The TSDoc part is minimal, we just extract summary right now.
- The concept of package modules that sit outside the src/dist folders in order to avoid ugly import paths feels tricky and I don't understand the fully spectrum of variation and dynamics possible here (what kind of setups projects will have etc.). Therefore I didn't try to design a system around it. I just exposed some config that users can use to provide a mapping however they need.
- Then came the need to allow users to easily provide the config. Doing this over the CLI seemed harder both to implement and to use for the user, becasue it was best configurewd as a mapping of keys to values. So that's what this PR does.
- The results of this PR can be seen on the nexus code base in this gist: https://gist.github.com/jasonkuhrt/d3824cfb9ad8c7ea20dcbe7e7eaf5ea3